### PR TITLE
initial attempt to catch errors (upper case to lower case)

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,6 @@
 
 resource "aws_s3_bucket" "consul-backup-bucket" {
-  bucket = "${var.name}-consul-backup"
+  bucket = lower("${var.name}-consul-backup")
 
   tags = {
     Name = "${var.name}-consul-backup"


### PR DESCRIPTION
 bucket only allows for lowercase alphanumeric characters and hyphens